### PR TITLE
Add support for caption in code blocks

### DIFF
--- a/lib/tdiary/style/markdown.rb
+++ b/lib/tdiary/style/markdown.rb
@@ -198,6 +198,13 @@ module TDiary
 							  else
 								  nil
 							  end
+				caption_part = ""
+				if language && language.include?(":")
+					language, *caption = language.split(":")
+					unless caption.empty?
+						caption_part = "<span class=\"caption\">#{escape_html(caption.join(":"))}</span>\n"
+					end
+				end
 				code = node.string_content
 				lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText
 				formatter = rouge_formatter(lexer)
@@ -208,7 +215,7 @@ module TDiary
 						if language
 							out(' lang="', language, '"')
 						end
-						out('><code>')
+						out(">#{caption_part}<code>")
 					else
 						out("<pre#{sourcepos(node)}")
 						if language
@@ -217,6 +224,7 @@ module TDiary
 							out(' class="highlight plaintext">')
 						end
 					end
+					out(caption_part)
 					out('<code>')
 					out(highlighted)
 					out('</code></pre>')

--- a/test/tdiary/style/markdown-test.rb
+++ b/test/tdiary/style/markdown-test.rb
@@ -551,7 +551,7 @@ p "OK"
       assert_equal(@html, @diary.to_html)
     end
 
-    def test_path_with_childe
+    def test_path_with_tilde
       source = <<-EOF
 # Code Blocks
 

--- a/test/tdiary/style/markdown-test.rb
+++ b/test/tdiary/style/markdown-test.rb
@@ -524,11 +524,11 @@ HTML<%=fn %Q(Hyper Text Markup Language)%> is a markup language<%=fn %Q(<a href=
       source = <<-EOF
 # Code Blocks
 
-```ruby:example1.rb
+```plaintext:example1.rb
 p "OK"
 ```
 
-~~~ruby:example2.rb
+~~~plaintext:example2.rb
 p "OK"
 ~~~
       EOF
@@ -538,9 +538,11 @@ p "OK"
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "Code Blocks" ) %></h3>
-<pre class="highlight ruby"><span class="caption">example1.rb</span><code>p "OK"
+<pre class="highlight plaintext"><span class="caption">example1.rb</span>
+<code>p "OK"
 </code></pre>
-<pre class="highlight ruby">span class="caption">example2.rb</span><code>p "OK"
+<pre class="highlight plaintext"><span class="caption">example2.rb</span>
+<code>p "OK"
 </code></pre>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>
@@ -553,11 +555,11 @@ p "OK"
       source = <<-EOF
 # Code Blocks
 
-```ruby:~/example1.rb
+```plaintext:~/example1.rb
 p "OK"
 ```
 
-~~~ruby:~/example2.rb
+~~~plaintext:~/example2.rb
 p "OK"
 ~~~
       EOF
@@ -567,9 +569,11 @@ p "OK"
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "Code Blocks" ) %></h3>
-<pre class="highlight ruby"><span class="caption">~/example1.rb</span><code>p "OK"
+<pre class="highlight plaintext"><span class="caption">~/example1.rb</span>
+<code>p "OK"
 </code></pre>
-<pre class="highlight ruby"><span class="caption">~/example1.rb</span><code>p "OK"
+<pre class="highlight plaintext"><span class="caption">~/example1.rb</span>
+<code>p "OK"
 </code></pre>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>
 </div>

--- a/test/tdiary/style/markdown-test.rb
+++ b/test/tdiary/style/markdown-test.rb
@@ -520,7 +520,7 @@ HTML<%=fn %Q(Hyper Text Markup Language)%> is a markup language<%=fn %Q(<a href=
   end
 
   class QiitaStyleCodeBlock < self
-    def test_basic
+    def test_caption
       source = <<-EOF
 # Code Blocks
 
@@ -551,7 +551,7 @@ p "OK"
       assert_equal(@html, @diary.to_html)
     end
 
-    def test_path_with_tilde
+    def test_caption_with_tilde
       source = <<-EOF
 # Code Blocks
 
@@ -573,6 +573,37 @@ p "OK"
 <code>p "OK"
 </code></pre>
 <pre class="highlight plaintext"><span class="caption">~/example2.rb</span>
+<code>p "OK"
+</code></pre>
+<%=section_leave_proc( Time.at( 1041346800 ) )%>
+</div>
+      EOF
+
+      assert_equal(@html, @diary.to_html)
+    end
+
+    def test_caption_with_backtick
+      source = <<-EOF
+# Code Blocks
+
+```plaintext:e`x`ample1.rb
+p "OK"
+```
+
+~~~plaintext:e`x`ample2.rb
+p "OK"
+~~~
+      EOF
+      @diary.append(source)
+
+      @html = <<-EOF
+<div class="section">
+<%=section_enter_proc( Time.at( 1041346800 ) )%>
+<h3><%= subtitle_proc( Time.at( 1041346800 ), "Code Blocks" ) %></h3>
+<pre class="highlight plaintext"><span class="caption">e`x`ample1.rb</span>
+<code>p "OK"
+</code></pre>
+<pre class="highlight plaintext"><span class="caption">e`x`ample2.rb</span>
 <code>p "OK"
 </code></pre>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>

--- a/test/tdiary/style/markdown-test.rb
+++ b/test/tdiary/style/markdown-test.rb
@@ -518,4 +518,64 @@ HTML<%=fn %Q(Hyper Text Markup Language)%> is a markup language<%=fn %Q(<a href=
 
     assert_equal(@html, @diary.to_html)
   end
+
+  class QiitaStyleCodeBlock < self
+    def test_basic
+      source = <<-EOF
+# Code Blocks
+
+```ruby:example1.rb
+p "OK"
+```
+
+~~~ruby:example2.rb
+p "OK"
+~~~
+      EOF
+      @diary.append(source)
+
+      @html = <<-EOF
+<div class="section">
+<%=section_enter_proc( Time.at( 1041346800 ) )%>
+<h3><%= subtitle_proc( Time.at( 1041346800 ), "Code Blocks" ) %></h3>
+<pre class="highlight ruby"><span class="caption">example1.rb</span><code>p "OK"
+</code></pre>
+<pre class="highlight ruby">span class="caption">example2.rb</span><code>p "OK"
+</code></pre>
+<%=section_leave_proc( Time.at( 1041346800 ) )%>
+</div>
+      EOF
+
+      assert_equal(@html, @diary.to_html)
+    end
+
+    def test_path_with_childe
+      source = <<-EOF
+# Code Blocks
+
+```ruby:~/example1.rb
+p "OK"
+```
+
+~~~ruby:~/example2.rb
+p "OK"
+~~~
+      EOF
+      @diary.append(source)
+
+      @html = <<-EOF
+<div class="section">
+<%=section_enter_proc( Time.at( 1041346800 ) )%>
+<h3><%= subtitle_proc( Time.at( 1041346800 ), "Code Blocks" ) %></h3>
+<pre class="highlight ruby"><span class="caption">~/example1.rb</span><code>p "OK"
+</code></pre>
+<pre class="highlight ruby"><span class="caption">~/example1.rb</span><code>p "OK"
+</code></pre>
+<%=section_leave_proc( Time.at( 1041346800 ) )%>
+</div>
+      EOF
+
+      assert_equal(@html, @diary.to_html)
+    end
+  end
 end

--- a/test/tdiary/style/markdown-test.rb
+++ b/test/tdiary/style/markdown-test.rb
@@ -558,52 +558,15 @@ p "OK"
 ```plaintext:~/example1.rb
 p "OK"
 ```
-
-~~~plaintext:~/example2.rb
-p "OK"
-~~~
       EOF
       @diary.append(source)
+      # note: tilde after three-tilde code fence is not supported by cmark...
 
       @html = <<-EOF
 <div class="section">
 <%=section_enter_proc( Time.at( 1041346800 ) )%>
 <h3><%= subtitle_proc( Time.at( 1041346800 ), "Code Blocks" ) %></h3>
 <pre class="highlight plaintext"><span class="caption">~/example1.rb</span>
-<code>p "OK"
-</code></pre>
-<pre class="highlight plaintext"><span class="caption">~/example2.rb</span>
-<code>p "OK"
-</code></pre>
-<%=section_leave_proc( Time.at( 1041346800 ) )%>
-</div>
-      EOF
-
-      assert_equal(@html, @diary.to_html)
-    end
-
-    def test_caption_with_backtick
-      source = <<-EOF
-# Code Blocks
-
-```plaintext:e`x`ample1.rb
-p "OK"
-```
-
-~~~plaintext:e`x`ample2.rb
-p "OK"
-~~~
-      EOF
-      @diary.append(source)
-
-      @html = <<-EOF
-<div class="section">
-<%=section_enter_proc( Time.at( 1041346800 ) )%>
-<h3><%= subtitle_proc( Time.at( 1041346800 ), "Code Blocks" ) %></h3>
-<pre class="highlight plaintext"><span class="caption">e`x`ample1.rb</span>
-<code>p "OK"
-</code></pre>
-<pre class="highlight plaintext"><span class="caption">e`x`ample2.rb</span>
 <code>p "OK"
 </code></pre>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>

--- a/test/tdiary/style/markdown-test.rb
+++ b/test/tdiary/style/markdown-test.rb
@@ -572,7 +572,7 @@ p "OK"
 <pre class="highlight plaintext"><span class="caption">~/example1.rb</span>
 <code>p "OK"
 </code></pre>
-<pre class="highlight plaintext"><span class="caption">~/example1.rb</span>
+<pre class="highlight plaintext"><span class="caption">~/example2.rb</span>
 <code>p "OK"
 </code></pre>
 <%=section_leave_proc( Time.at( 1041346800 ) )%>


### PR DESCRIPTION
On Qiita, we can append something caption for a code block as a part of the language name in its code fence, like: `~~~ruby:example.rb`

http://qiita.com/Qiita/items/c686397e4a0f4f11683d#code---%E3%82%B3%E3%83%BC%E3%83%89%E3%81%AE%E6%8C%BF%E5%85%A5

By this change, such part will be separated from the language name and exposed as a `span` element with `caption` class.
